### PR TITLE
Remember Me Option

### DIFF
--- a/.ggrc.json.example
+++ b/.ggrc.json.example
@@ -2,6 +2,7 @@
   "username": "fake@example.com",
   "password": "123456",
   "2FA": false,
+  "remember_me" : false,
   "sendgrid_api_key": "",
   "sendgrid_cc": "test@example.com",
   "blacklist": "socks,kindle edition,floss"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .env
 /eng.traineddata
 .ggrc.json
+user_data/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ After running `gg init`, you'll have a `.ggrc.json` file in your directory. It w
 
 If you have two factor authentication enabled, set the `2FA` option. The script will wait for you to enter your code. 
 
+If you set `remember_me` to true, you should only have to enter your two factor code the first time you start the script. 
+
 ### Blacklist
 
 If there are types of giveaways you always want to skip, you can add a comma separated list of keywords 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Other available commands:
 | `gg --page=[number]` | Starts script on given page number (eg. `gg --page=34`) |
 | `gg --config==[string]` | Specify path to JSON config file (eg. `gg --config=/var/myconfig.json`) |
 
+If you would rather have the output write to a file then stdout, pipe it like:
+
+`gg > gg.log 2>&1`
+
 ## Configuration
 
 After running `gg init`, you'll have a `.ggrc.json` file in your directory. It will look like this:
@@ -58,6 +62,7 @@ After running `gg init`, you'll have a `.ggrc.json` file in your directory. It w
   "username": "test@example.com",
   "password": "123456",
   "2FA": false,
+  "remember_me": false,
   "sendgrid_api_key": "",
   "sendgrid_cc": "",
   "blacklist": "floss,socks,ties"
@@ -69,6 +74,7 @@ After running `gg init`, you'll have a `.ggrc.json` file in your directory. It w
 | username  | Your Amazon Account Email Address  |
 | password  | Your Amazon Account Password  |
 | 2FA | Set true if you have two factor authentication enabled |
+| remember_me | Set true if you want to stay logged in between running scripts |
 | sendgrid_api_key | Your [sendgrid](https://sendgrid.com/) API key, if you want to receive an email when you win. Optional |
 | sendgrid_cc | An email address to be cc'ed if you win |
 | blacklist | Comma delimited list of keywords to avoid when entering giveaways. Optional |

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ if (args.sendgrid_cc && args.sendgrid_cc !== '') {
 		args: ['--mute-audio']
 	};
 	if (args['remember_me']) {
-		config.userDataDir = "./user_data";
+		config.userDataDir = './user_data';
 	}
 	const browser = await puppeteer.launch(config);
 	const page = await browser.newPage();
@@ -65,7 +65,14 @@ if (args.sendgrid_cc && args.sendgrid_cc !== '') {
 	}
 
 	//sign in
-	await signIn(page, username, password, pageNumber, args['2FA'], args['remember_me']);
+	await signIn(
+		page,
+		username,
+		password,
+		pageNumber,
+		args['2FA'],
+		args['remember_me']
+	);
 
 	//enter giveaways
 	await enterGiveaways(page, args.page || 1);

--- a/index.js
+++ b/index.js
@@ -49,10 +49,14 @@ if (args.sendgrid_cc && args.sendgrid_cc !== '') {
 
 //start index code
 (async () => {
-	const browser = await puppeteer.launch({
+	let config = {
 		headless: false,
 		args: ['--mute-audio']
-	});
+	};
+	if (args['remember_me']) {
+		config.userDataDir = "./user_data";
+	}
+	const browser = await puppeteer.launch(config);
 	const page = await browser.newPage();
 
 	let pageNumber = 1;
@@ -61,7 +65,7 @@ if (args.sendgrid_cc && args.sendgrid_cc !== '') {
 	}
 
 	//sign in
-	await signIn(page, username, password, pageNumber, args['2FA']);
+	await signIn(page, username, password, pageNumber, args['2FA'], args['remember_me']);
 
 	//enter giveaways
 	await enterGiveaways(page, args.page || 1);

--- a/src/init.js
+++ b/src/init.js
@@ -26,6 +26,12 @@ exports.handler = function(argv) {
 					default: false
 				},
 				{
+					name: 'remember_me',
+					message: 'Stay logged in',
+					type: 'confirm',
+					default: false
+				},
+				{
 					name: 'sendgrid_api_key',
 					message: 'Sendgrid API Key (optional, for emails on win):',
 					default: ''

--- a/src/signIn.js
+++ b/src/signIn.js
@@ -56,21 +56,21 @@ module.exports = async function(
 	await signInPromise;
 
 	if (twoFactorAuth) {
-		//wait here until user submits two factor auth code
-		console.log('Waiting for two factor authentication...');
-
-		if (rememberMe) {
-			try {
+		try {
+			await page.waitForSelector('#auth-mfa-otpcode', {
+				timeout: 1000
+			});
+			if (rememberMe) {
 				await page.waitForSelector('#auth-mfa-remember-device', {
 					timeout: 1000
 				});
 				await page.click('#auth-mfa-remember-device');
-			} catch (error) {
-				//couldn't click remember device, no big deal
 			}
+			console.log('Waiting for two factor authentication...');
+			const twoFactorAuthPromise = page.waitForNavigation({ timeout: 0 });
+			await twoFactorAuthPromise;
+		} catch (error) {
+			//couldn't click remember device, no big deal
 		}
-
-		const twoFactorAuthPromise = page.waitForNavigation({ timeout: 0 });
-		await twoFactorAuthPromise;
 	}
 };

--- a/src/signIn.js
+++ b/src/signIn.js
@@ -31,6 +31,9 @@ module.exports = async function(
 	await page.click('#ap_password');
 	await page.type('#ap_password', password);
 
+	await page.waitForSelector('[name=rememberMe]');
+	await page.click('[name=rememberMe]');
+
 	const signInPromise = page.waitForNavigation();
 	await page.waitForSelector('#signInSubmit');
 	await page.click('#signInSubmit');

--- a/src/signIn.js
+++ b/src/signIn.js
@@ -35,7 +35,6 @@ module.exports = async function(
 		console.log('No email field');
 	}
 
-
 	await page.waitForSelector('#ap_password');
 	await page.click('#ap_password');
 	await page.type('#ap_password', password);


### PR DESCRIPTION
Adds a `remember_me` option. If true, checks the keep me signed in checkbox and the remember device checkboxes, and stores user session information in local folder. This prevents user from having to re-enter 2FA when restarting script.

Forked from PR #58, this will resolve #57 and #36. Hopefully will reduce number of times sign in buttons or password re-entries are presented as well. Going to let this run for awhile to make sure it doesn't break anything before merging. 