### PR TITLE
Filter Giveaway by price

### DIFF
--- a/.ggrc.json.example
+++ b/.ggrc.json.example
@@ -6,5 +6,6 @@
   "sendgrid_api_key": "",
   "sendgrid_cc": "test@example.com",
   "blacklist": "socks,kindle edition,floss",
-  "chromeExecutablePath": "/path/to/Chrome"
+  "chromeExecutablePath": "/path/to/Chrome",
+  "minimum_price": 0
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ After running `gg init`, you'll have a `.ggrc.json` file in your directory. It w
   "sendgrid_api_key": "",
   "sendgrid_cc": "",
   "blacklist": "floss,socks,ties",
-  "chromeExecutablePath": ""
+  "chromeExecutablePath": "",
+  "minimum_price": 10
 }
 ```
 
@@ -81,7 +82,7 @@ After running `gg init`, you'll have a `.ggrc.json` file in your directory. It w
 | sendgrid_cc | An email address to be cc'ed if you win |
 | blacklist | Comma delimited list of keywords to avoid when entering giveaways. Optional |
 | chromeExecutablePath | Path to your own install of Chrome. Optional |
-
+| minimum_price | Skip the giveaways with items with price lower than the minimum price |
 ### Two factor Authentication (2FA)
 
 If you have two factor authentication enabled, set the `2FA` option. The script will wait for you to enter your code. 

--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ if (args.sendgrid_cc && args.sendgrid_cc !== '') {
 if (args.chromeExecutablePath && args.chromeExecutablePath !== '') {
 	process.env.CHROME_EXECUTABLE_PATH = args.chromeExecutablePath;
 }
+if (args.minimum_price && args.minimum_price !== '') {
+	process.env.MINIMUM_PRICE = args.minimum_price;
+}
 
 //start index code
 (async () => {

--- a/src/init.js
+++ b/src/init.js
@@ -41,6 +41,12 @@ exports.handler = function(argv) {
 					message: 'Black List (optional, comma separated list)',
 					type: 'input',
 					default: ''
+				},
+				{
+					name: 'minimum_price',
+					message: 'Minimum item value (optional, default 0)',
+					type: 'input',
+					default: 0
 				}
 			])
 			.then(answers => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,10 +60,25 @@ function checkStringForWords(wordList, str) {
 	return match;
 }
 
+/**
+ * Checks if an item price is
+ * Greater than the minimum price
+ * @param {Number} minPrice
+ * @param {Number} itemPrice
+ * @return {boolean}
+ */
+function checkMinPrice(minPrice, itemPrice) {
+	if (typeof minPrice !== 'number' || typeof itemPrice !== 'number') {
+		return true;
+	}
+	return itemPrice >= minPrice ? true : false;
+}
+
 module.exports = {
 	asyncForEach,
 	sendSystemNotification,
-	checkStringForWords
+	checkStringForWords,
+	checkMinPrice
 };
 
 /**

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,4 +1,4 @@
-const { checkStringForWords } = require('./utils');
+const { checkStringForWords, checkMinPrice } = require('./utils');
 
 describe('checkStringForWords', () => {
 	test('matches whole words in string', () => {
@@ -63,5 +63,14 @@ describe('checkStringForWords', () => {
 		expect(match).toBeNull();
 		match = checkStringForWords(null, null);
 		expect(match).toBeNull();
+	});
+
+	test('return true if price is bigger than min', () => {
+		let match = checkMinPrice(10, 15);
+		expect(match).toEqual(true);
+		match = checkMinPrice(10, 8);
+		expect(match).toEqual(false);
+		match = checkMinPrice(10, 10);
+		expect(match).toEqual(true);
 	});
 });


### PR DESCRIPTION
I've added the possibility to filter the giveaways based on the price of the item.

If an Item is less than an amount X, the giveaway will not be entered.

This will avoid winning some items that are not needed, and maybe that it's not worth even reselling.
The default value of the property will be zero.

In case the program fails to fetch a value,or the comparison fails,it will simply ignore the filter and enter the giveaway.

The init script has been updated accordingly. ( Didn't find instructions in the readme how to test-run it alone )