### PR TITLE
add log for minimum price check skips

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -3,7 +3,8 @@ const urlTypes = {
 	LOST: 'L',
 	ENDED: 'E',
 	ALREADY: 'A',
-	CANNOT: 'C'
+	CANNOT: 'C',
+	MINIMUM_PRICE: 'M'
 };
 
 // Export the object to be used in this format: `urlTypes.WIN`


### PR DESCRIPTION
Log if entry was skipped because it was lower than minimum price check, so it will be skipped if encountered again without having to go to the url and do the price check again.

Also make sure url saved is always the url for the entry on the giveaways screen. This should resolve #104 